### PR TITLE
User and Staff are now linked

### DIFF
--- a/MyA/forms.py
+++ b/MyA/forms.py
@@ -4,7 +4,19 @@
 """
 
 from django.forms import *
+from django.contrib.auth.forms import UserChangeForm
 from MyA.models import *
+
+class UserEditForm(UserChangeForm):
+    """ A user edit form. This form inherits from UserChangeForm and only changes the fields which are used/shown
+    """
+    class Meta:
+        model = User
+        # overwrites the fields of the super class
+        fields = {'username','password'}
+
+    def __init__(self,*args,**kwargs):
+        super().__init__(*args,**kwargs)
 
 # Form with fields to create or update staff
 class StaffForm(ModelForm):
@@ -27,13 +39,11 @@ class StaffForm(ModelForm):
 class StaffProfileForm(ModelForm):
     class Meta:
         model = Staffs
-        fields = ('gender', 'firstname', 'lastname', 'nickname', 'pwd', 'phone', 'fax', 'mobile', 'email', 'title', 'position')
+        fields = ('gender', 'firstname', 'lastname', 'phone', 'fax', 'mobile', 'email', 'title', 'position')
         labels = {
             'gender':'Anrede',
             'firstname':'Vorname',
             'lastname':'Nachname',
-            'nickname':'Nickname',
-            'pwd':'Passwort',
             'phone':'Telefon',
             'fax': 'Fax',
             'mobile': 'Mobil',

--- a/MyA/models.py
+++ b/MyA/models.py
@@ -5,14 +5,18 @@ File Decsription
 
 from django.db import models
 from datetime import datetime
+from django.contrib.auth.models import User
 
 # Create your models here.
 
 # id = models.AutoField(primary_key=True)
 
 class Staffs(models.Model):
-    nickname = models.CharField('nickname', max_length=75)
-    pwd = models.CharField('pwd', max_length=100)
+    # this connects the staff to the django auth user model
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+
+    #nickname = models.CharField('nickname', max_length=75)
+    #pwd = models.CharField('pwd', max_length=100)
     firstname = models.CharField('firstname', max_length=100)
     lastname = models.CharField('lastname', max_length=100)
     GENDER=(

--- a/Semesterprojekt/templates/navigation.html
+++ b/Semesterprojekt/templates/navigation.html
@@ -14,11 +14,19 @@
         <div id="navbar" class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
                 {# Definiere the Menüpunkte mit dem jeweiligen Namen aus der urls.py  #}  }
-                {% with 'startseite mitarbeiter profil terminkalender logout' as list %}
+                {% with 'startseite profil terminkalender logout' as list %}
                     {% for urlname in list.split %}
                         <li {% if request.resolver_match.url_name == urlname %}class="active"{% endif %}><a href="{% url urlname %}">{{ urlname|title }}</a></li>
                     {% endfor %}
                 {% endwith %}
+
+                {% if request.user.is_superuser %}
+                    {% with 'mitarbeiter' as admin_only_list %}
+                        {% for urlname in admin_only_list.split %}
+                            <li {% if request.resolver_match.url_name == urlname %}class="active"{% endif %}><a href="{% url urlname %}">{{ urlname|title }}</a></li>
+                        {% endfor %}
+                    {% endwith %}
+                {% endif %}
             </ul>
         </div><!--/.nav-collapse -->
     </div>

--- a/Semesterprojekt/templates/staff/password.html
+++ b/Semesterprojekt/templates/staff/password.html
@@ -1,5 +1,3 @@
-<!-- File Decsription: HTML template for the site "neuerMA" !-->
-
 {% extends 'base.html' %}
 {% load bootstrap3 %}
 
@@ -10,7 +8,6 @@
 
         {% csrf_token %}
 
-        {% bootstrap_form user_form layout='horizontal' %}
         {% bootstrap_form form layout='horizontal' %}
 
         <button type="submit" class="btn btn-primary">Anlegen</button>

--- a/Semesterprojekt/templates/staff/staff.html
+++ b/Semesterprojekt/templates/staff/staff.html
@@ -17,14 +17,16 @@
             <th>Nachname</th>
             <th>Titel</th>
             <th>Position</th>
+            <td>&nbsp</td>
         </tr>
         <tr>
             {% for staff in staffs %}
                 <tr>
-                <td>{{ staffs.first }}</td>
-                <td>{{ staffs.last }}</td>
-                <td>{{ staffs.title }}</td>
-                <td>{{ staffs.position }}</td>
+                <td>{{ staff.firstname }}</td>
+                <td>{{ staff.lastname }}</td>
+                <td>{{ staff.title }}</td>
+                <td>{{ staff.position }}</td>
+                <td><a href="{% url 'editStaff' pk=staff.id %}">{% bootstrap_icon 'edit' %}</a></td>
                 </tr>
 
             {% endfor %}

--- a/Semesterprojekt/urls.py
+++ b/Semesterprojekt/urls.py
@@ -24,9 +24,11 @@ admin.autodiscover()
 
 urlpatterns = (
     url(r'^admin/', admin.site.urls),
-    url(r'^startseite/$', MyA.views.homesite, name='startseite'),
+    url(r'^$', MyA.views.homesite, name='startseite'),
     url(r'^mitarbeiter/$', MyA.views.get_staff, name='mitarbeiter'),
     url(r'^mitarbeiter/neuerMA/$', MyA.views.new_Staff, name='newStaff'),
+    url(r'^mitarbeiter/editMa/(?P<pk>[0-9]+)/change//?$', MyA.views.new_Staff, name='editStaff'),
+    url(r'^mitarbeiter/editMa/(?P<pk>[0-9]+)/password//?$', MyA.views.set_password, name='setPasswordForUser'),
     url(r'^profil/$', MyA.views.myProfile, name='profil'),
     url(r'^kalender/$', MyA.views.calendar, name='terminkalender'),
     url(r'^login/$', auth_views.login, name='login'),


### PR DESCRIPTION
- The auth user and custom staff model are now linked, in the create and edit fields both entities will be updated
- The staff forms is updated
- The pwd and nickname attributes are removed from the staff model as they are already existent in the User model
- The staff views are accessible by the admin only
- The staff navigation-element is shown to the admin only

Further:
- The root page now connects to the start page

Todo:
- some cancel buttons don't work right now
- the redirects after sending a form do not work as expected